### PR TITLE
Remove `boost/json` import

### DIFF
--- a/src/AYON_AssetResolvingProvider_REST.h
+++ b/src/AYON_AssetResolvingProvider_REST.h
@@ -6,7 +6,6 @@
 #include <boost/beast/core.hpp>
 #include <boost/beast/http.hpp>
 #include <boost/beast/version.hpp>
-#include <boost/json.hpp>
 #include <boost/property_tree/json_parser.hpp>
 #include "AYON_AssetResolvingProvider.h"
 


### PR DESCRIPTION
It's not being used and it prevents the plugin from building with Houdini's USD.