### PR TITLE
added windows and linux compile plugins for Houdini 20.5

### DIFF
--- a/BuildPlugins/HouLinux/Houdini205_Py310_Linux.cmake
+++ b/BuildPlugins/HouLinux/Houdini205_Py310_Linux.cmake
@@ -1,0 +1,44 @@
+# LinuxPy310Houdini20
+
+# Variables that need to be set by the plugin (the env variables will be checked by the main cmakeLists script and an error will accrue if one or more are missing)
+# AR_PXR_INCLUDE_DIR
+# AR_PXR_LIB_DIR
+# AR_PYTHON_LIB_NUMBER
+# AR_BOOST_INCLUDE_DIR
+# BOOST_LIB_DIR
+# AR_PYTHON_LIB_DIR
+# AR_PYTHON_INCLUDE_DIR
+# AR_PXR_LIB_PREFIX
+
+
+# plugin dependent settings 
+set(AR_HOUDINI_ROOT $ENV{HFS} CACHE PATH "Houdini install directory")
+if (NOT DEFINED ENV{HFS})
+    message(FATAL_ERROR "HFS Env Variable is not defined. But BuildPlugin LinuxPy311Houdini20 needs it to function.") 
+endif()
+
+set(AR_HOUDINI_LIB_DIR ${AR_HOUDINI_ROOT}/dsolib)
+set(AR_HOUDINI_INCLUDE_DIR ${AR_HOUDINI_ROOT}/toolkit/include)
+
+set(AR_PXR_LIB_DIR ${AR_HOUDINI_ROOT}/dsolib)
+set(AR_PXR_LIB_PREFIX "pxr_") #the library prefix is divergent between Linux and win, some times software developers also rename the prefix
+set(AR_PXR_INCLUDE_DIR ${AR_HOUDINI_INCLUDE_DIR})
+
+# setting up python 
+set(AR_PYTHON_LIB_NUMBER python310)
+set(AR_PYTHON_LIB_DIR ${AR_HOUDINI_ROOT}/python/lib)
+set(AR_PYTHON_INCLUDE_DIR ${AR_HOUDINI_INCLUDE_DIR}/python3.10)
+#set(AR_PYTHON_LIB_SITEPACKAGES ${AR_PYTHON_LIB_DIR}/${AR_PYTHON_LIB}/site-packages)
+
+# setting up boost 
+add_compile_definitions(HBOOST_ALL_NO_LIB)
+set(AR_BOOST_NAMESPACE hboost) # overwriting boost name space because Houdini renamed it to hboost internally
+set(AR_BOOST_INCLUDE_DIR ${AR_HOUDINI_INCLUDE_DIR}/${AR_BOOST_NAMESPACE})
+set(BOOST_LIB_DIR ${AR_HOUDINI_INCLUDE_DIR})
+
+# setting Cxx11Abi to on because Hou20 needs it to function 
+
+set(GLIBCXX_USE_CXX11_ABI 1)
+
+# Houdini include dir (might shadow some other library but that's what we want)
+link_directories(${AR_HOUDINI_LIB_DIR})

--- a/BuildPlugins/HouLinux/Houdini205_Py311_Linux.cmake
+++ b/BuildPlugins/HouLinux/Houdini205_Py311_Linux.cmake
@@ -1,0 +1,44 @@
+# LinuxPy310Houdini20
+
+# Variables that need to be set by the plugin (the env variables will be checked by the main cmakeLists script and an error will accrue if one or more are missing)
+# AR_PXR_INCLUDE_DIR
+# AR_PXR_LIB_DIR
+# AR_PYTHON_LIB_NUMBER
+# AR_BOOST_INCLUDE_DIR
+# BOOST_LIB_DIR
+# AR_PYTHON_LIB_DIR
+# AR_PYTHON_INCLUDE_DIR
+# AR_PXR_LIB_PREFIX
+
+
+# plugin dependent settings 
+set(AR_HOUDINI_ROOT $ENV{HFS} CACHE PATH "Houdini install directory")
+if (NOT DEFINED ENV{HFS})
+    message(FATAL_ERROR "HFS Env Variable is not defined. But BuildPlugin LinuxPy311Houdini20 needs it to function.") 
+endif()
+
+set(AR_HOUDINI_LIB_DIR ${AR_HOUDINI_ROOT}/dsolib)
+set(AR_HOUDINI_INCLUDE_DIR ${AR_HOUDINI_ROOT}/toolkit/include)
+
+set(AR_PXR_LIB_DIR ${AR_HOUDINI_ROOT}/dsolib)
+set(AR_PXR_LIB_PREFIX "pxr_") #the library prefix is divergent between Linux and win, some times software developers also rename the prefix
+set(AR_PXR_INCLUDE_DIR ${AR_HOUDINI_INCLUDE_DIR})
+
+# setting up python 
+set(AR_PYTHON_LIB_NUMBER python311)
+set(AR_PYTHON_LIB_DIR ${AR_HOUDINI_ROOT}/python/lib)
+set(AR_PYTHON_INCLUDE_DIR ${AR_HOUDINI_INCLUDE_DIR}/python3.11)
+#set(AR_PYTHON_LIB_SITEPACKAGES ${AR_PYTHON_LIB_DIR}/${AR_PYTHON_LIB}/site-packages)
+
+# setting up boost 
+add_compile_definitions(HBOOST_ALL_NO_LIB)
+set(AR_BOOST_NAMESPACE hboost) # overwriting boost name space because Houdini renamed it to hboost internally
+set(AR_BOOST_INCLUDE_DIR ${AR_HOUDINI_INCLUDE_DIR}/${AR_BOOST_NAMESPACE})
+set(BOOST_LIB_DIR ${AR_HOUDINI_INCLUDE_DIR})
+
+# setting Cxx11Abi to on because Hou20 needs it to function 
+
+set(GLIBCXX_USE_CXX11_ABI 1)
+
+# Houdini include dir (might shadow some other library but that's what we want)
+link_directories(${AR_HOUDINI_LIB_DIR})

--- a/BuildPlugins/HouWin/Houdini205_Py310_Win.cmake
+++ b/BuildPlugins/HouWin/Houdini205_Py310_Win.cmake
@@ -1,0 +1,42 @@
+# LinuxPy310Houdini20
+
+# Variables that need to be set by the plugin ( the env variables will be checked by the main cmakeLists script and an error will accrue if one or more are missing )
+# AR_PXR_INCLUDE_DIR
+# AR_PXR_LIB_DIR
+# AR_PYTHON_LIB_NUMBER
+# AR_BOOST_INCLUDE_DIR
+# BOOST_LIB_DIR
+# AR_PYTHON_LIB_DIR
+# AR_PYTHON_INCLUDE_DIR
+# AR_PXR_LIB_PREFIX
+
+
+# plugin dependent settings 
+set(AR_HOUDINI_ROOT $ENV{HFS} CACHE PATH "Houdini install directory")
+if (NOT DEFINED ENV{HFS})
+    message(FATAL_ERROR "HFS Env Variable is not defined. But BuildPlugin LinuxPy310Houdini20_5 needs it to function.") 
+endif()
+
+set(AR_HOUDINI_LIB_DIR ${AR_HOUDINI_ROOT}/custom/houdini/dsolib)
+set(AR_HOUDINI_INCLUDE_DIR ${AR_HOUDINI_ROOT}/toolkit/include)
+
+set(AR_PXR_LIB_DIR ${AR_HOUDINI_ROOT}/custom/houdini/dsolib)
+set(AR_PXR_LIB_PREFIX "libpxr_") #the library prefix is divergent between Linux and win, some times software developers also rename the prefix
+set(AR_PXR_INCLUDE_DIR ${AR_HOUDINI_INCLUDE_DIR})
+
+# setting up python 
+set(AR_PYTHON_LIB_NUMBER python310)
+set(AR_PYTHON_LIB_DIR ${AR_HOUDINI_ROOT}/${AR_PYTHON_LIB_NUMBER}/libs)
+set(AR_PYTHON_INCLUDE_DIR ${AR_HOUDINI_INCLUDE_DIR}/python3.10)
+#set(AR_PYTHON_LIB_SITEPACKAGES ${AR_PYTHON_LIB_DIR}/${AR_PYTHON_LIB}/site-packages)
+
+
+# setting up boost 
+add_compile_definitions(HBOOST_ALL_NO_LIB)
+set(AR_BOOST_NAMESPACE hboost) # overwriting boost name space because Houdini renamed it to hboost internally
+set(AR_BOOST_INCLUDE_DIR ${AR_HOUDINI_INCLUDE_DIR}/${AR_BOOST_NAMESPACE})
+set(BOOST_LIB_DIR ${AR_HOUDINI_INCLUDE_DIR})
+
+
+# Houdini include dir (might shadow some other library but that's what we want)
+link_directories(${AR_HOUDINI_LIB_DIR})

--- a/BuildPlugins/HouWin/Houdini205_Py311_Win.cmake
+++ b/BuildPlugins/HouWin/Houdini205_Py311_Win.cmake
@@ -1,0 +1,42 @@
+# LinuxPy310Houdini20
+
+# Variables that need to be set by the plugin ( the env variables will be checked by the main cmakeLists script and an error will accrue if one or more are missing )
+# AR_PXR_INCLUDE_DIR
+# AR_PXR_LIB_DIR
+# AR_PYTHON_LIB_NUMBER
+# AR_BOOST_INCLUDE_DIR
+# BOOST_LIB_DIR
+# AR_PYTHON_LIB_DIR
+# AR_PYTHON_INCLUDE_DIR
+# AR_PXR_LIB_PREFIX
+
+
+# plugin dependent settings 
+set(AR_HOUDINI_ROOT $ENV{HFS} CACHE PATH "Houdini install directory")
+if (NOT DEFINED ENV{HFS})
+    message(FATAL_ERROR "HFS Env Variable is not defined. But BuildPlugin LinuxPy311Houdini20_5 needs it to function.") 
+endif()
+
+set(AR_HOUDINI_LIB_DIR ${AR_HOUDINI_ROOT}/custom/houdini/dsolib)
+set(AR_HOUDINI_INCLUDE_DIR ${AR_HOUDINI_ROOT}/toolkit/include)
+
+set(AR_PXR_LIB_DIR ${AR_HOUDINI_ROOT}/custom/houdini/dsolib)
+set(AR_PXR_LIB_PREFIX "libpxr_") #the library prefix is divergent between Linux and win, some times software developers also rename the prefix
+set(AR_PXR_INCLUDE_DIR ${AR_HOUDINI_INCLUDE_DIR})
+
+# setting up python 
+set(AR_PYTHON_LIB_NUMBER python311)
+set(AR_PYTHON_LIB_DIR ${AR_HOUDINI_ROOT}/${AR_PYTHON_LIB_NUMBER}/libs)
+set(AR_PYTHON_INCLUDE_DIR ${AR_HOUDINI_INCLUDE_DIR}/python3.11)
+#set(AR_PYTHON_LIB_SITEPACKAGES ${AR_PYTHON_LIB_DIR}/${AR_PYTHON_LIB}/site-packages)
+
+
+# setting up boost 
+add_compile_definitions(HBOOST_ALL_NO_LIB)
+set(AR_BOOST_NAMESPACE hboost) # overwriting boost name space because Houdini renamed it to hboost internally
+set(AR_BOOST_INCLUDE_DIR ${AR_HOUDINI_INCLUDE_DIR}/${AR_BOOST_NAMESPACE})
+set(BOOST_LIB_DIR ${AR_HOUDINI_INCLUDE_DIR})
+
+
+# Houdini include dir (might shadow some other library but that's what we want)
+link_directories(${AR_HOUDINI_LIB_DIR})


### PR DESCRIPTION
## Changelog Description
this PR adds build scripts for hou20.5 py311 and py310 for windows and linux. 

the scripts are the same as hou20.0 but the python number changed. 


## Additional info
they are not tested on windows. 

## Testing notes:

1. in your ayon usd addon set this lakefs path `lakefs://ayon-usd/add_hou_205/`
2. add 2 entrys for hou 20.5 win and 2 for linux 
3. add the following data into the corresponding lakefs object paths 
``` 
AyonUsdResolverBin/HouLinux/Houdini205_Py310_Linux_Linux_x86_64.zip
AyonUsdResolverBin/HouLinux/Houdini205_Py311_Linux_Linux_x86_64.zip

AyonUsdResolverBin/HouWin/Houdini205_Py310_Win_Windows_AMD64.zip
AyonUsdResolverBin/HouWin/Houdini205_Py311_Win_Windows_AMD64.zip 
```

4. start houdini and it should download. 
