### PR TITLE
Add Houdini 21 and Maya 2026 build plugins

### DIFF
--- a/BuildPlugins/HouLinux/Houdini21_Py311_Linux.cmake
+++ b/BuildPlugins/HouLinux/Houdini21_Py311_Linux.cmake
@@ -1,0 +1,44 @@
+# LinuxPy311Houdini21
+
+# Variables that need to be set by the plugin (the env variables will be checked by the main cmakeLists script and an error will accrue if one or more are missing)
+# AR_PXR_INCLUDE_DIR
+# AR_PXR_LIB_DIR
+# AR_PYTHON_LIB_NUMBER
+# AR_BOOST_INCLUDE_DIR
+# BOOST_LIB_DIR
+# AR_PYTHON_LIB_DIR
+# AR_PYTHON_INCLUDE_DIR
+# AR_PXR_LIB_PREFIX
+
+
+# plugin dependent settings 
+set(AR_HOUDINI_ROOT $ENV{HFS} CACHE PATH "Houdini install directory")
+if (NOT DEFINED ENV{HFS})
+    message(FATAL_ERROR "HFS Env Variable is not defined. But BuildPlugin LinuxPy311Houdini21 needs it to function.") 
+endif()
+
+set(AR_HOUDINI_LIB_DIR ${AR_HOUDINI_ROOT}/dsolib)
+set(AR_HOUDINI_INCLUDE_DIR ${AR_HOUDINI_ROOT}/toolkit/include)
+
+set(AR_PXR_LIB_DIR ${AR_HOUDINI_ROOT}/dsolib)
+set(AR_PXR_LIB_PREFIX "pxr_") #the library prefix is divergent between Linux and win, some times software developers also rename the prefix
+set(AR_PXR_INCLUDE_DIR ${AR_HOUDINI_INCLUDE_DIR})
+
+# setting up python 
+set(AR_PYTHON_LIB_NUMBER python311)
+set(AR_PYTHON_LIB_DIR ${AR_HOUDINI_ROOT}/python/lib)
+set(AR_PYTHON_INCLUDE_DIR ${AR_HOUDINI_INCLUDE_DIR}/python3.11)
+#set(AR_PYTHON_LIB_SITEPACKAGES ${AR_PYTHON_LIB_DIR}/${AR_PYTHON_LIB}/site-packages)
+
+# setting up boost 
+add_compile_definitions(HBOOST_ALL_NO_LIB)
+set(AR_BOOST_NAMESPACE hboost) # overwriting boost name space because Houdini renamed it to hboost internally
+set(AR_BOOST_INCLUDE_DIR ${AR_HOUDINI_INCLUDE_DIR}/${AR_BOOST_NAMESPACE})
+set(BOOST_LIB_DIR ${AR_HOUDINI_INCLUDE_DIR})
+
+# setting Cxx11Abi to on because Hou20 needs it to function 
+
+set(GLIBCXX_USE_CXX11_ABI 1)
+
+# Houdini include dir (might shadow some other library but that's what we want)
+link_directories(${AR_HOUDINI_LIB_DIR})

--- a/BuildPlugins/HouWin/Houdini21_Py311_Win.cmake
+++ b/BuildPlugins/HouWin/Houdini21_Py311_Win.cmake
@@ -1,0 +1,42 @@
+# WinPy311Houdini21
+
+# Variables that need to be set by the plugin ( the env variables will be checked by the main cmakeLists script and an error will accrue if one or more are missing )
+# AR_PXR_INCLUDE_DIR
+# AR_PXR_LIB_DIR
+# AR_PYTHON_LIB_NUMBER
+# AR_BOOST_INCLUDE_DIR
+# BOOST_LIB_DIR
+# AR_PYTHON_LIB_DIR
+# AR_PYTHON_INCLUDE_DIR
+# AR_PXR_LIB_PREFIX
+
+
+# plugin dependent settings 
+set(AR_HOUDINI_ROOT $ENV{HFS} CACHE PATH "Houdini install directory")
+if (NOT DEFINED ENV{HFS})
+    message(FATAL_ERROR "HFS Env Variable is not defined. But BuildPlugin WinPy311Houdini21 needs it to function.") 
+endif()
+
+set(AR_HOUDINI_LIB_DIR ${AR_HOUDINI_ROOT}/custom/houdini/dsolib)
+set(AR_HOUDINI_INCLUDE_DIR ${AR_HOUDINI_ROOT}/toolkit/include)
+
+set(AR_PXR_LIB_DIR ${AR_HOUDINI_ROOT}/custom/houdini/dsolib)
+set(AR_PXR_LIB_PREFIX "libpxr_") #the library prefix is divergent between Linux and win, some times software developers also rename the prefix
+set(AR_PXR_INCLUDE_DIR ${AR_HOUDINI_INCLUDE_DIR})
+
+# setting up python 
+set(AR_PYTHON_LIB_NUMBER python311)
+set(AR_PYTHON_LIB_DIR ${AR_HOUDINI_ROOT}/${AR_PYTHON_LIB_NUMBER}/libs)
+set(AR_PYTHON_INCLUDE_DIR ${AR_HOUDINI_INCLUDE_DIR}/python3.11)
+#set(AR_PYTHON_LIB_SITEPACKAGES ${AR_PYTHON_LIB_DIR}/${AR_PYTHON_LIB}/site-packages)
+
+
+# setting up boost 
+add_compile_definitions(HBOOST_ALL_NO_LIB)
+set(AR_BOOST_NAMESPACE hboost) # overwriting boost name space because Houdini renamed it to hboost internally
+set(AR_BOOST_INCLUDE_DIR ${AR_HOUDINI_INCLUDE_DIR}/${AR_BOOST_NAMESPACE})
+set(BOOST_LIB_DIR ${AR_HOUDINI_INCLUDE_DIR})
+
+
+# Houdini include dir (might shadow some other library but that's what we want)
+link_directories(${AR_HOUDINI_LIB_DIR})

--- a/BuildPlugins/MayaLinux/Maya2026_Py311_Linux.cmake
+++ b/BuildPlugins/MayaLinux/Maya2026_Py311_Linux.cmake
@@ -1,0 +1,48 @@
+# LinuxPy311Maya2026
+
+# Variables that need to be set by the plugin (the env variables will be checked by the main cmakeLists script and an error will occur if one ore more are missing)
+# AR_PXR_INCLUDE_DIR
+# AR_PXR_LIB_DIR
+# AR_PYTHON_LIB_NUMBER
+# AR_BOOST_INCLUDE_DIR
+# BOOST_LIB_DIR
+# AR_PYTHON_LIB_DIR
+# AR_PYTHON_INCLUDE_DIR
+# AR_PXR_LIB_PREFIX
+
+
+# MAYAUSDPATH /usr/autodesk/mayausd/maya2024/0.25.0_202310160731-bbc8cc8/mayausd
+# MAYAUSDDEVKITPATH /path/to/devkit
+# MAYAPATH /usr/autodesk/maya2024
+
+# plugin dependent settings 
+set(AR_MAYA_ROOT $ENV{MAYAPATH} CACHE PATH "Maya install directory")
+if (NOT DEFINED ENV{MAYAPATH})
+  message(FATAL_ERROR "MAYAPATH Env Variable is not defined. But BuildPlugin LinuxPy310Houdini20 needs it to function.") 
+endif()
+set(AR_MAYAUSDPLUGIN_ROOT $ENV{MAYAUSDPATH} CACHE PATH "Maya usd Plugin install directory")
+if (NOT DEFINED ENV{MAYAUSDPATH})
+  message(FATAL_ERROR "MAYAUSDPATH Env Variable is not defined. But BuildPlugin LinuxPy310Houdini20 needs it to function.") 
+endif()
+set(AR_MAYAUSDPLUGIN_DEVKIT_ROOT $ENV{MAYAUSDDEVKITPATH} CACHE PATH "Maya usd DevKit Plugin install directory")
+if (NOT DEFINED ENV{MAYAUSDDEVKITPATH})
+  message(FATAL_ERROR "MAYAUSDDEVKITPATH Env Variable is not defined. But BuildPlugin LinuxPy310Houdini20 needs it to function.") 
+endif()
+
+
+set(AR_PXR_LIB_DIR ${AR_MAYAUSDPLUGIN_ROOT}/USD/lib)
+set(AR_PXR_LIB_PREFIX "usd_") #the library prefix is divergent between Linux and win, some times software developers also rename the prefix
+set(AR_PXR_INCLUDE_DIR ${AR_MAYAUSDPLUGIN_DEVKIT_ROOT}/include)
+
+
+# setting up python 
+set(AR_PYTHON_LIB_NUMBER python311)
+set(AR_PYTHON_LIB_DIR ${AR_MAYA_ROOT}/lib)
+set(AR_PYTHON_INCLUDE_DIR ${AR_MAYA_ROOT}/include/Python311/Python)
+#set(AR_PYTHON_LIB_SITEPACKAGES ${AR_PYTHON_LIB_DIR}/${AR_PYTHON_LIB}/site-packages)
+
+
+set(AR_BOOST_INCLUDE_DIR ${AR_MAYAUSDPLUGIN_DEVKIT_ROOT}/include/boost)
+set(BOOST_LIB_DIR ${AR_MAYAUSDPLUGIN_ROOT}/USD/lib)
+
+set(GLIBCXX_USE_CXX11_ABI 1)

--- a/BuildPlugins/MayaWin/Maya2026_Py311_Win.cmake
+++ b/BuildPlugins/MayaWin/Maya2026_Py311_Win.cmake
@@ -1,0 +1,49 @@
+# WinPy311Maya2026
+
+# Variables that need to be set by the plugin (the env variables will be checked by the main cmakeLists script and an error will accrue if one ore more are missing)
+# AR_PXR_INCLUDE_DIR
+# AR_PXR_LIB_DIR
+# AR_PYTHON_LIB_NUMBER
+# AR_BOOST_INCLUDE_DIR
+# BOOST_LIB_DIR
+# AR_PYTHON_LIB_DIR
+# AR_PYTHON_INCLUDE_DIR
+# AR_PXR_LIB_PREFIX
+
+
+# MAYAUSDPATH /usr/autodesk/mayausd/maya2024/0.25.0_202310160731-bbc8cc8/mayausd
+# MAYAUSDDEVKITPATH /path/to/devkit
+# MAYAPATH /usr/autodesk/maya2024
+
+# plugin dependent settings 
+set(AR_MAYA_ROOT $ENV{MAYAPATH} CACHE PATH "Maya install directory")
+if (NOT DEFINED ENV{MAYAPATH})
+  message(FATAL_ERROR "MAYAPATH Env Variable is not defined. But BuildPlugin LinuxPy310Houdini20 needs it to function.") 
+endif()
+set(AR_MAYAUSDPLUGIN_ROOT $ENV{MAYAUSDPATH} CACHE PATH "Maya usd Plugin install directory")
+if (NOT DEFINED ENV{MAYAUSDPATH})
+  message(FATAL_ERROR "MAYAUSDPATH Env Variable is not defined. But BuildPlugin LinuxPy310Houdini20 needs it to function.") 
+endif()
+set(AR_MAYAUSDPLUGIN_DEVKIT_ROOT $ENV{MAYAUSDDEVKITPATH} CACHE PATH "Maya usd DevKit Plugin install directory")
+if (NOT DEFINED ENV{MAYAUSDDEVKITPATH})
+  message(FATAL_ERROR "MAYAUSDDEVKITPATH Env Variable is not defined. But BuildPlugin LinuxPy310Houdini20 needs it to function.") 
+endif()
+
+
+set(AR_PXR_LIB_DIR ${AR_MAYAUSDPLUGIN_DEVKIT_ROOT}/lib)
+set(AR_PXR_LIB_PREFIX "usd_") #the library prefix is divergent between Linux and win, some times software developers also rename the prefix
+set(AR_PXR_INCLUDE_DIR ${AR_MAYAUSDPLUGIN_DEVKIT_ROOT}/include)
+
+
+# 'python310.lib'
+# setting up python 
+set(AR_PYTHON_LIB_NUMBER python311)
+set(AR_PYTHON_LIB_DIR ${AR_MAYA_ROOT}/lib)
+set(AR_PYTHON_INCLUDE_DIR ${AR_MAYA_ROOT}/include/Python311/Python)
+#set(AR_PYTHON_LIB_SITEPACKAGES ${AR_PYTHON_LIB_DIR}/${AR_PYTHON_LIB}/site-packages)
+
+set(AR_BOOST_EXTEND -vc143-mt-x64-1_81)
+set(AR_BOOST_INCLUDE_DIR ${AR_MAYAUSDPLUGIN_DEVKIT_ROOT}/include/boost-1_81)
+set(BOOST_LIB_DIR ${AR_MAYAUSDPLUGIN_DEVKIT_ROOT}/lib)
+
+#set(GLIBCXX_USE_CXX11_ABI 1)


### PR DESCRIPTION
## Changelog Description
Add Houdini 21 and Maya 2026 build plugins

## Additional Notes
This PR https://github.com/ynput/ayon-cpp-api/pull/35 is not merged yet and include important fixes such as the logging in logic.

## Testing notes:
1. Create your `build_conf.yaml`. you can name it what you want.
2. Specify desired targets to build in your `build_conf.yaml`. e.g.
    ```yaml
    # Houdini
    Houdini21_Py311_Linux:
      COMPILEPLUGIN: "HouLinux/Houdini21_Py311_Linux"
      HFS: "/opt/hfs21.0"  # path to Houdini 21 install directory.
    
    Houdini21_Py311_Win:
      COMPILEPLUGIN: "HouWin/Houdini21_Py311_Win"
      HFS: "C:\\Program Files\\Side Effects Software\\Houdini 21.0"  # path to my Houdini install directory.
    
    # Maya
    Maya2026_Py311_Linux:
      COMPILEPLUGIN: "MayaLinux/Maya2026_Py311_Linux"
      MAYAUSDPATH: "/usr/autodesk/mayausd/maya2026/0.31.0/mayausd"
      MAYAUSDDEVKITPATH: "/path/to/devkit"
      MAYAPATH: "/usr/autodesk/maya2026"
    
    Maya2026_Py311_Win:
      COMPILEPLUGIN: "MayaWin/Maya2026_Py311_Win"
      MAYAUSDPATH: "C:\\Program Files\\Autodesk\\MayaUSD\\Maya2026\\0.31.0\\mayausd"
      MAYAUSDDEVKITPATH: "H:\\programs\\Autodesk\\Maya2026\\devkit"
      MAYAPATH: "C:\\Users\\<username>\\Documents\\maya\\2026"
    ```
3. Setup & Build
    ```
    python Project.py --setup
    python Project.py --runStageGRP "Generate Release" --setVars {\"BuildConf\":\"build_conf.yaml\"}
    ```


Resolve #47 
