### PR TITLE
Force resolver to be used also for local paths

### DIFF
--- a/src/AyonUsdResolver/helpers/resolutionFunctions.cpp
+++ b/src/AyonUsdResolver/helpers/resolutionFunctions.cpp
@@ -83,5 +83,5 @@ _ResolveAnchored(const std::string &anchorPath, const std::string &path) {
         resolvedPath = TfStringCatPaths(anchorPath, path);
     }
 
-    return TfPathExists(resolvedPath) ? ArResolvedPath(TfAbsPath(resolvedPath)) : ArResolvedPath();
+    return ArResolvedPath(TfAbsPath(resolvedPath));
 }

--- a/src/AyonUsdResolver/plugInfo.json.in
+++ b/src/AyonUsdResolver/plugInfo.json.in
@@ -5,8 +5,7 @@
         "Types": {
           "@AR_AYONUSDRESOLVER_USD_CXX_CLASS_NAME@": {
             "bases": ["ArResolver"],
-            "implementsContexts": true,
-            "uriSchemes": ["ayon", "ayon+entity"]
+            "implementsContexts": true
           }
         }
       },

--- a/src/AyonUsdResolver/resolver.cpp
+++ b/src/AyonUsdResolver/resolver.cpp
@@ -181,7 +181,7 @@ AyonUsdResolver::_Resolve(const std::string &assetPath) const {
         TF_DEBUG(AYONUSDRESOLVER_RESOLVER)
                 .Msg("Resolver::_Resolve( '%s' ) is relative path\n", pathToResolve->c_str());
         ArResolvedPath resolvedPath = _ResolveAnchored(ArchGetCwd(), *pathToResolve);
-        if (resolvedPath) {
+        if (TfPathExists(resolvedPath.GetPathString())) {
             return resolvedPath;
         }
 

--- a/src/AyonUsdResolver/resolver.cpp
+++ b/src/AyonUsdResolver/resolver.cpp
@@ -181,11 +181,16 @@ AyonUsdResolver::_Resolve(const std::string &assetPath) const {
         TF_DEBUG(AYONUSDRESOLVER_RESOLVER)
                 .Msg("Resolver::_Resolve( '%s' ) is relative path\n", pathToResolve->c_str());
         ArResolvedPath resolvedPath = _ResolveAnchored(ArchGetCwd(), *pathToResolve);
-        if (TfPathExists(resolvedPath.GetPathString())) {
-            return resolvedPath;
+        
+        if (! TfPathExists(resolvedPath.GetPathString())) {
+            TF_DEBUG(AYONUSDRESOLVER_RESOLVER)
+                .Msg("Resolver::_Resolve('%s') resolved to a non-existent location: '%s'\n", 
+                    pathToResolve->c_str(), 
+                    resolvedPath.GetPathString().c_str()
+                );
         }
-
-        return ArResolvedPath(*pathToResolve);
+        
+        return resolvedPath;
     }
 
     TF_DEBUG(AYONUSDRESOLVER_RESOLVER)


### PR DESCRIPTION
## Changelog Description
Forcing USD to use AYON resolver also for local paths + remove check if file exists.

## Additional review information
Removing the condition can break other things and conditions based on the returned value.

## Testing notes:
1. start with this step
2. follow this step
