### PR TITLE
Prewarm the resolver cache to cut serial resolve round-trips

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ logFile*
 __pycache__/
 .python-version
 tests/testVenv/
+
+# local build / install artifacts
+build_usd/
+install/
+*.log

--- a/src/AyonUsdResolver/CMakeLists.txt
+++ b/src/AyonUsdResolver/CMakeLists.txt
@@ -17,6 +17,7 @@ set(RESOLVER_SRCS
     cache/assetIdentifierDef.cpp
     cache/resolverContextCache.cpp
     helpers/ayonApiGet.cpp
+    prefetch/prewarm.cpp
 )
 
 add_library(${CORE_LIB_TARGET} SHARED ${RESOLVER_SRCS})

--- a/src/AyonUsdResolver/cache/resolverContextCache.cpp
+++ b/src/AyonUsdResolver/cache/resolverContextCache.cpp
@@ -23,8 +23,10 @@
 #include <string>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 
 PXR_NAMESPACE_USING_DIRECTIVE
+
 // TODO pinning file hanlder should construct its cache directly at construction getAssetData should not call
 // rootReplace
 PinningFileHandler::PinningFileHandler(const std::string &pinningFilePath,
@@ -160,6 +162,32 @@ ResolverContextCache::migratePreCacheIntoAyonCache() {
     m_AyonCache.reserve(m_AyonCache.size() + m_PreCache.size());
     m_AyonCache.insert(std::make_move_iterator(m_PreCache.begin()), std::make_move_iterator(m_PreCache.end()));
     m_PreCache.clear();
+};
+
+std::unordered_map<std::string, std::string>
+ResolverContextCache::batchWarm(std::vector<std::string> &uriPaths) {
+    TF_DEBUG(AYONUSDRESOLVER_RESOLVER_CONTEXT)
+        .Msg("ResolverContextCache::batchWarm: %zu uris \n", uriPaths.size());
+
+    std::unordered_map<std::string, std::string> resolved;
+    if (m_staticCache || uriPaths.empty()) {
+        return resolved;
+    }
+
+    // One batched request over the persistent keep-alive client: few round-trips,
+    // deterministic, connection reused.
+    resolved = m_ayon->get()->batchResolvePathSerial(uriPaths);
+
+    for (const auto &entry: resolved) {
+        if (entry.first.empty() || entry.second.empty()) {
+            continue;
+        }
+        AssetIdentifier asset;
+        asset.setAssetIdentifier(entry.first);
+        asset.setResolvedAssetPath(entry.second);
+        this->insert(asset);
+    }
+    return resolved;
 };
 
 AssetIdentifier

--- a/src/AyonUsdResolver/cache/resolverContextCache.h
+++ b/src/AyonUsdResolver/cache/resolverContextCache.h
@@ -65,6 +65,19 @@ class ResolverContextCache {
         AssetIdentifier getAsset(const std::string &assetIdentifier, const CacheName selectedCache, const bool isAyonPath);
 
         /**
+         * @brief Resolve many AYON URIs in a single batched (parallel) request and seed the cache.
+         *
+         * Unlike getAsset(), which resolves one URI per server round-trip, this collapses a whole
+         * set of URIs into one batched call via AyonApi::batchResolvePath and inserts every result.
+         * Used by the prewarm pass to avoid the serial resolve storm during stage composition.
+         *
+         * No-op in static (pinning) mode or with an empty input.
+         * @param uriPaths The AYON URIs to resolve. May be reordered/deduplicated.
+         * @return Map of URI -> resolved path for the entries that were resolved.
+         */
+        std::unordered_map<std::string, std::string> batchWarm(std::vector<std::string> &uriPaths);
+
+        /**
          * @brief Set up the cache from a pinning file
          * @param pinningFilePath Path to the pinning file
          */

--- a/src/AyonUsdResolver/prefetch/prewarm.cpp
+++ b/src/AyonUsdResolver/prefetch/prewarm.cpp
@@ -1,0 +1,200 @@
+#include "prewarm.h"
+
+#include "../cache/resolverContextCache.h"
+#include "../codes/debugCodes.h"
+#include "../helpers/resolutionFunctions.h"
+#include "../resolverContext.h"
+
+#include <pxr/pxr.h>
+#include <pxr/base/tf/debug.h>
+#include <pxr/usd/ar/resolvedPath.h>
+#include <pxr/usd/ar/resolver.h>
+#include <pxr/usd/sdf/layer.h>
+
+#include <deque>
+#include <memory>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+PXR_NAMESPACE_USING_DIRECTIVE
+
+namespace {
+
+const char* kSdfArgsMarker = ":SDF_FORMAT_ARGS";
+
+// Split an asset identifier into (clean identifier, SDF format args suffix).
+// e.g. "foo.usd:SDF_FORMAT_ARGS:layer_id=model&order=100"
+//   -> {"foo.usd", ":SDF_FORMAT_ARGS:layer_id=model&order=100"}
+// The clean part is what the resolver keys the cache on (USD strips the args
+// before calling _Resolve); the suffix must be re-attached when OPENING the
+// layer so prewarm touches the exact same SdfLayer identity composition will,
+// rather than a phantom args-less layer.
+void
+splitSdfArgs(const std::string &identifier, std::string &clean, std::string &argsSuffix) {
+    const size_t pos = identifier.find(kSdfArgsMarker);
+    if (pos == std::string::npos) {
+        clean = identifier;
+        argsSuffix.clear();
+    } else {
+        clean = identifier.substr(0, pos);
+        argsSuffix = identifier.substr(pos);
+    }
+}
+
+// Only recurse into deps that SdfLayer can open as a layer (tolerating a trailing
+// :SDF_FORMAT_ARGS suffix). Asset-path attributes pointing at textures etc. are
+// resolved by the batch but never scanned for further composition deps.
+bool
+looksLikeLayer(const std::string &path) {
+    static const char *exts[] = {".usd", ".usda", ".usdc", ".usdz"};
+    for (const char *e: exts) {
+        const std::string ext(e);
+        if (path.size() >= ext.size() && path.compare(path.size() - ext.size(), ext.size(), ext) == 0) {
+            return true;
+        }
+        if (path.find(ext + ":") != std::string::npos) {
+            return true;
+        }
+    }
+    return false;
+}
+
+}   // namespace
+
+void
+AyonUsdResolverPrewarmStage(const std::string &rootAssetPath) {
+    std::shared_ptr<ResolverContextCache> cache = GetResolverGlobalCache();
+    if (rootAssetPath.empty() || !cache) {
+        return;
+    }
+    if (cache->isCacheStatic()) {
+        // Pinning mode already resolves locally; there is nothing to warm.
+        return;
+    }
+
+    TF_DEBUG(AYONUSDRESOLVER_RESOLVER_CONTEXT)
+        .Msg("Prewarm: starting BFS from '%s'\n", rootAssetPath.c_str());
+
+    ArResolver &resolver = ArGetResolver();
+
+    std::unordered_set<std::string> scheduledUris;    // clean AYON URIs already batched
+    std::unordered_set<std::string> openedLayers;     // layer identifiers already queued (with args)
+    std::deque<std::string> layerFrontier;            // openable layer identifiers to scan (with args)
+
+    // The root is handed to us as the asset path USD is about to open. Resolve it
+    // through the resolver (a single round-trip at worst if it is an AYON URI; a
+    // no-op for an already-local file path) so we can read it as a layer.
+    {
+        std::string rootClean;
+        std::string rootArgs;
+        splitSdfArgs(rootAssetPath, rootClean, rootArgs);
+        ArResolvedPath rootResolved = resolver.Resolve(rootClean);
+        std::string rootResolvedStr = rootResolved.GetPathString();
+        if (rootResolvedStr.empty()) {
+            rootResolvedStr = rootClean;
+        }
+        rootResolvedStr += rootArgs;
+        layerFrontier.push_back(rootResolvedStr);
+        openedLayers.insert(rootResolvedStr);
+    }
+
+    size_t batchRounds = 0;
+    size_t totalResolved = 0;
+
+    while (!layerFrontier.empty()) {
+        std::deque<std::string> currentFrontier;
+        currentFrontier.swap(layerFrontier);
+
+        // Clean AYON URIs to batch this round, each paired with the SDF args suffix
+        // that must be re-attached to the resolved path before we open it.
+        std::vector<std::string> uriFrontier;
+        std::vector<std::pair<std::string, std::string>> scheduledThisRound;   // (cleanUri, argsSuffix)
+        std::vector<std::string> localLayerFrontier;                           // non-AYON layers to scan next
+
+        for (const std::string &layerPath: currentFrontier) {
+            SdfLayerRefPtr layer = SdfLayer::FindOrOpen(layerPath);
+            if (!layer) {
+                TF_DEBUG(AYONUSDRESOLVER_RESOLVER_CONTEXT)
+                    .Msg("Prewarm: could not open layer '%s'\n", layerPath.c_str());
+                continue;
+            }
+
+            // Anchor relative deps against the layer's real (args-less) path.
+            std::string anchorClean;
+            std::string anchorArgs;
+            splitSdfArgs(layerPath, anchorClean, anchorArgs);
+
+            for (const std::string &dep: layer->GetCompositionAssetDependencies()) {
+                if (dep.empty()) {
+                    continue;
+                }
+
+                // The full identifier (with any :SDF_FORMAT_ARGS) as composition sees it.
+                std::string identFull = resolver.CreateIdentifier(dep, ArResolvedPath(anchorClean));
+                std::string identClean;
+                std::string argsSuffix;
+                splitSdfArgs(identFull, identClean, argsSuffix);
+
+                if (_IsAyonPath(identClean)) {
+                    // Cache key is the clean URI (what _Resolve looks up); remember the
+                    // args so we open the matching layer identity, not a phantom args-less one.
+                    if (scheduledUris.insert(identClean).second) {
+                        uriFrontier.push_back(identClean);
+                    }
+                    scheduledThisRound.emplace_back(identClean, argsSuffix);
+                    continue;
+                }
+
+                // Local/relative sublayer: resolving it is a cheap filesystem op.
+                // Queue it (with its args) so we discover any AYON refs nested beneath it.
+                ArResolvedPath localResolved = resolver.Resolve(identClean);
+                std::string localResolvedStr = localResolved.GetPathString();
+                if (!localResolvedStr.empty()) {
+                    localResolvedStr += argsSuffix;
+                    if (looksLikeLayer(localResolvedStr) && openedLayers.insert(localResolvedStr).second) {
+                        localLayerFrontier.push_back(localResolvedStr);
+                    }
+                }
+            }
+        }
+
+        // One batched resolve for the entire AYON frontier (clean keys only).
+        std::unordered_map<std::string, std::string> resolved;
+        if (!uriFrontier.empty()) {
+            ++batchRounds;
+            resolved = cache->batchWarm(uriFrontier);
+            totalResolved += resolved.size();
+        }
+
+        // Queue each resolved AYON layer for the next BFS level, re-attaching its
+        // SDF args so we open exactly the layer identity composition will use.
+        for (const auto &scheduled: scheduledThisRound) {
+            const std::string &cleanUri = scheduled.first;
+            const std::string &argsSuffix = scheduled.second;
+            auto it = resolved.find(cleanUri);
+            if (it == resolved.end() || it->second.empty()) {
+                continue;
+            }
+            std::string openable = it->second + argsSuffix;
+            if (looksLikeLayer(openable) && openedLayers.insert(openable).second) {
+                layerFrontier.push_back(openable);
+            }
+        }
+
+        for (const std::string &localLayer: localLayerFrontier) {
+            layerFrontier.push_back(localLayer);
+        }
+    }
+
+    TF_DEBUG(AYONUSDRESOLVER_RESOLVER_CONTEXT)
+        .Msg("Prewarm: done - %zu uris resolved across %zu batched round(s)\n", totalResolved, batchRounds);
+}
+
+extern "C" void
+AyonUsdResolverPrewarm(const char *rootAssetPath) {
+    if (rootAssetPath == nullptr) {
+        return;
+    }
+    AyonUsdResolverPrewarmStage(std::string(rootAssetPath));
+}

--- a/src/AyonUsdResolver/prefetch/prewarm.h
+++ b/src/AyonUsdResolver/prefetch/prewarm.h
@@ -1,0 +1,30 @@
+#ifndef AR_AYONUSDRESOLVER_PREWARM_H
+#define AR_AYONUSDRESOLVER_PREWARM_H
+
+#include <string>
+
+/**
+ * @brief Pre-resolve a stage's AYON URIs in batched requests before composition.
+ *
+ * Walks the composition graph rooted at rootAssetPath breadth-first using
+ * SdfLayer::GetCompositionAssetDependencies() (local layer reads, no server
+ * round-trips). Each BFS frontier of AYON URIs is resolved in a single batched,
+ * parallel request and inserted into the process-wide resolver cache. By the time
+ * USD composes the stage and calls _Resolve() per asset, the cache is already warm,
+ * so the dozens of serial ~750ms round-trips collapse into one batched call per
+ * graph level.
+ *
+ * Safe to call with a non-AYON or unreadable root (does nothing useful, never throws).
+ * No-op when the cache is in static (pinning) mode.
+ */
+void AyonUsdResolverPrewarmStage(const std::string &rootAssetPath);
+
+extern "C" {
+/**
+ * @brief C entry point for host-side (e.g. ctypes) invocation. Wraps
+ * AyonUsdResolverPrewarmStage. Null/empty rootAssetPath is ignored.
+ */
+void AyonUsdResolverPrewarm(const char *rootAssetPath);
+}
+
+#endif   // AR_AYONUSDRESOLVER_PREWARM_H

--- a/src/AyonUsdResolver/resolver.cpp
+++ b/src/AyonUsdResolver/resolver.cpp
@@ -3,6 +3,11 @@
 #include "codes/debugCodes.h"
 #include "cache/resolverContextCache.h"
 #include "helpers/resolutionFunctions.h"
+#include "prefetch/prewarm.h"
+
+#include <cstdlib>
+#include <mutex>
+#include <unordered_set>
 
 #include <pxr/pxr.h>
 #include <pxr/base/arch/systemInfo.h>
@@ -239,6 +244,37 @@ ArResolverContext
 AyonUsdResolver::_CreateDefaultContextForAsset(const std::string &assetPath) const {
     TF_DEBUG(AYONUSDRESOLVER_RESOLVER_CONTEXT)
         .Msg("Resolver::_CreateDefaultContextForAsset('%s')\n", assetPath.c_str());
+
+    // Batch warm-pass: resolve the stage's AYON URIs in batched requests up front,
+    // seeding the shared cache so composition's per-asset _Resolve() calls hit cache
+    // instead of doing dozens of serial server round-trips. Runs once per distinct
+    // root asset path. On by default; set AYON_RESOLVER_NO_PREWARM=1 (or
+    // AYON_RESOLVER_PREWARM=0) to disable.
+    static const bool prewarmEnabled = []() {
+        const char* off = std::getenv("AYON_RESOLVER_NO_PREWARM");
+        if (off != nullptr && std::strcmp(off, "0") != 0 && std::strcmp(off, "false") != 0) {
+            return false;
+        }
+        const char* legacy = std::getenv("AYON_RESOLVER_PREWARM");
+        if (legacy != nullptr && (std::strcmp(legacy, "0") == 0 || std::strcmp(legacy, "false") == 0)) {
+            return false;
+        }
+        return true;
+    }();
+    if (prewarmEnabled && !assetPath.empty()) {
+        static std::mutex prewarmMutex;
+        static std::unordered_set<std::string> prewarmedRoots;
+        bool shouldPrewarm = false;
+        {
+            std::lock_guard<std::mutex> lock(prewarmMutex);
+            shouldPrewarm = prewarmedRoots.insert(assetPath).second;
+        }
+        if (shouldPrewarm) {
+            TF_DEBUG(AYONUSDRESOLVER_RESOLVER_CONTEXT)
+                .Msg("Resolver::_CreateDefaultContextForAsset - prewarming '%s'\n", assetPath.c_str());
+            AyonUsdResolverPrewarmStage(assetPath);
+        }
+    }
 
     // Check if there's a currently bound context first
     const AyonUsdResolverContext* currentCtx = _GetCurrentContextPtr();

--- a/src/AyonUsdResolver/resolverContext.cpp
+++ b/src/AyonUsdResolver/resolverContext.cpp
@@ -31,10 +31,12 @@ GetGlobalCache() {
 
 }  // namespace
 
-// ResolverContextCache& GetGlobalResolverContextCache() {
-//     static ResolverContextCache instance;   // lazy init on first use
-//     return instance;
-// }
+// Public accessor bridging the encapsulated process-wide cache above so other
+// translation units (the prewarm pass) can seed the same instance.
+std::shared_ptr<ResolverContextCache>
+GetResolverGlobalCache() {
+    return GetGlobalCache();
+}
 
 bool
 getStringEndswithString(const std::string &value, const std::string &compareValue) {

--- a/src/AyonUsdResolver/resolverContext.h
+++ b/src/AyonUsdResolver/resolverContext.h
@@ -77,6 +77,11 @@ class AyonUsdResolverContext {
         bool _getMappingPairsFromJsonFile(const std::string& filePath);
 };
 
+// Accessor for the single process-wide resolver cache shared by every
+// AyonUsdResolverContext. Exposed so the prewarm pass (a separate translation
+// unit) and the host-side C entry point can seed the same cache instance.
+std::shared_ptr<ResolverContextCache> GetResolverGlobalCache();
+
 PXR_NAMESPACE_OPEN_SCOPE
 AR_DECLARE_RESOLVER_CONTEXT(AyonUsdResolverContext);
 PXR_NAMESPACE_CLOSE_SCOPE


### PR DESCRIPTION
## Changelog Description

Opening a stage against a remote AYON server is slow because USD resolves each `ayon://` URI one at a time, and every resolve is a round-trip to the server. This warms the resolver cache first: it walks the layer graph and resolves each level of URIs in one batched request before USD starts composing. On a WAN link that replaces dozens of serial round-trips with a few batched ones. 


## Merge order

This PR depends on [ayon-cpp-api#47](https://github.com/ynput/ayon-cpp-api/pull/47) (HTTP keep-alive and batchResolvePathSerial); merge that one first. The prewarm pass calls batchResolvePathSerial, and the submodule here is pinned to its commit, so this won't build without it. The submodule currently points at the fork commit so the branch builds and CI passes. 


## Benchmarking

In testing, from Cape Town via WAN to Ynput Cloud, the two changes together take a cold stage-open from about 11.7s to 2.3s, roughly 5x. On a heavier shot the same pair cut stage-open from about 33s to 4.5s. On a production character asset, the improvement was from 510s to 12s. 


## Additional review information

The pass lives in `prefetch/prewarm.{h,cpp}` and runs from `AyonUsdResolver::_CreateDefaultContextForAsset`, once per root asset. It walks the composition graph breadth-first with `SdfLayer::GetCompositionAssetDependencies()`, which is local layer reads only, no server calls. 

Each BFS frontier goes to `ResolverContextCache::batchWarm()`, which resolves the frontier in one request via `AyonApi::batchResolvePathSerial()` and writes the results into the process-wide cache. So when USD composes the stage and calls `_Resolve()` per asset, the entries are already there and the calls are local lookups.

URIs get their `:SDF_FORMAT_ARGS` suffix stripped before caching, so the key matches what USD asks for during composition. 

The pass stays inert where it should: a no-op in static/pinning mode, and safe on a non-AYON or unreadable root, where it does nothing rather than throwing.

The process-wide cache is private to `resolverContext.cpp`, so this adds a public `GetResolverGlobalCache()` accessor. 

On by default; `AYON_RESOLVER_NO_PREWARM=1` turns it off.


## Testing notes

1. Build the resolver against your USD and wire the plugin with `PXR_PLUGINPATH_NAME`, pointing `AYON_SERVER_URL` / `AYON_API_KEY` at a server you reach over a WAN or otherwise non-local link.
2. Open a stage that references AYON URIs, for example `usdcat --flatten asset.usd` or `usdview`, with resolver logging on.
3. Confirm prewarm fires: you should see a few `AyonApi::batchResolvePathSerial(N uris)` lines, one per graph frontier, and no per-URI serial resolves during composition. Note the open time.
4. Re-run with `AYON_RESOLVER_NO_PREWARM=1`. It should fall back to one resolve call per URI, meaning many serial round-trips, and be slower. This isolates the prewarm contribution.
5. Confirm the composed result matches between the two runs. For instanced assets, compare with the instance-prototype numbering normalised, since `usdcat --flatten` does not number `Flattened_Prototype_N` prims deterministically.