### PR TITLE
Expand variables in path

### DIFF
--- a/src/AyonUsdResolver/cache/assetIdentifierDef.cpp
+++ b/src/AyonUsdResolver/cache/assetIdentifierDef.cpp
@@ -1,9 +1,92 @@
 #include "assetIdentifierDef.h"
 
+#include <cctype>
+#include <cstdlib>
 #include <iostream>
 #include <ostream>
 #include <sstream>
 #include <string>
+
+namespace {
+
+/**
+ * @brief Expands environment variables and ~ in a file-system path.
+ *
+ * Supported formats:
+ *   ~/path          — replaced with HOME (or USERPROFILE on Windows)
+ *   $VAR/path       — bare dollar-sign variable
+ *   ${VAR}/path     — brace-delimited variable
+ */
+static std::string
+expandPathVars(const std::string &path) {
+    if (path.empty()) {
+        return path;
+    }
+
+    std::string result;
+    result.reserve(path.size());
+
+    size_t i = 0;
+
+    // Expand leading ~
+    if (path[0] == '~' && (path.size() == 1 || path[1] == '/' || path[1] == '\\')) {
+        const char *home = std::getenv("HOME");
+#ifdef _WIN32
+        if (!home) {
+            home = std::getenv("USERPROFILE");
+        }
+#endif
+        if (home) {
+            result += home;
+        }
+        else {
+            result += '~';
+        }
+        i = 1;
+    }
+
+    while (i < path.size()) {
+        if (path[i] == '$') {
+            size_t j = i + 1;
+            if (j < path.size() && path[j] == '{') {
+                // ${VAR} form
+                ++j;
+                size_t end = path.find('}', j);
+                if (end != std::string::npos) {
+                    std::string varName = path.substr(j, end - j);
+                    const char *val = std::getenv(varName.c_str());
+                    if (val) {
+                        result += val;
+                    }
+                    i = end + 1;
+                    continue;
+                }
+            }
+            else {
+                // $VAR form — collect [A-Za-z0-9_] characters
+                size_t end = j;
+                while (end < path.size()
+                       && (std::isalnum(static_cast<unsigned char>(path[end])) || path[end] == '_')) {
+                    ++end;
+                }
+                if (end > j) {
+                    std::string varName = path.substr(j, end - j);
+                    const char *val = std::getenv(varName.c_str());
+                    if (val) {
+                        result += val;
+                    }
+                    i = end;
+                    continue;
+                }
+            }
+        }
+        result += path[i++];
+    }
+
+    return result;
+}
+
+} // namespace
 
 PXR_NAMESPACE_USING_DIRECTIVE
 
@@ -25,7 +108,7 @@ AssetIdentifier::setResolvedAssetPath(const std::string &inResolvedAssetPath) {
     if (!isModifiable()) {
         return false;
     }
-    m_resolvedAssetPath = ArResolvedPath(inResolvedAssetPath);
+    m_resolvedAssetPath = ArResolvedPath(expandPathVars(inResolvedAssetPath));
     return true;
 };
 


### PR DESCRIPTION
## Changelog Description
Expand `~`, `$VAR` and `{VAR}` style variables in path.

## Additional review information
Expansion is applied only in `setResolvedAssetPath(const std::string &)` — the overload that receives raw string paths from pinning files, cache misses, and memcached. The `ArResolvedPath` overload is left untouched since those paths should already be fully resolved.

> [!NOTE]
> To be useful with https://github.com/ynput/ayon-core/pull/1884

## Testing notes:
Setup variables in roots
Resolve USD assets with the resolver build
