### PR TITLE
Add missing inlcude

### DIFF
--- a/src/AyonUsdResolver/resolver.cpp
+++ b/src/AyonUsdResolver/resolver.cpp
@@ -6,6 +6,7 @@
 
 #include <pxr/pxr.h>
 #include <pxr/base/arch/systemInfo.h>
+#include <pxr/base/tf/fileUtils.h>
 #include <pxr/base/tf/pathUtils.h>
 #include <pxr/base/tf/debug.h>
 #include <pxr/usd/ar/defaultResolver.h>


### PR DESCRIPTION
## Changelog Description
Fix the merged [PR](https://github.com/ynput/ayon-usd-resolver/pull/76), which is missing one include in `/src/AyonUsdResolver/resolver.cpp`.

## Testing notes:
Tested already with the merged PR, but forgot to push this change.
