### PR TITLE
Fix ayon-cpp-dev-tools submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 
 [submodule "ext/ayon-cpp-dev-tools"]
   path = ext/ayon-cpp-dev-tools
-  url = https://github.com/cpt-cabbage/ayon-cpp-dev-tools.git
+	url = https://github.com/ynput/ayon-cpp-dev-tools.git
 [submodule "automator"]
 	path = automator
 	url = https://github.com/ynput/ayon-automator.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ext/ayon-cpp-api"]
   path = ext/ayon-cpp-api
-  url = https://github.com/ynput/ayon-cpp-api.git
+  url = git@github.com:ynput/ayon-cpp-api.git
 
 [submodule "ext/ayon-cpp-dev-tools"]
   path = ext/ayon-cpp-dev-tools

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 
 [submodule "ext/ayon-cpp-dev-tools"]
   path = ext/ayon-cpp-dev-tools
-	url = https://github.com/ynput/ayon-cpp-dev-tools.git
+	url = git@github.com:ynput/ayon-cpp-dev-tools.git
 [submodule "automator"]
 	path = automator
 	url = https://github.com/ynput/ayon-automator.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,4 +7,4 @@
 	url = git@github.com:ynput/ayon-cpp-dev-tools.git
 [submodule "automator"]
 	path = automator
-	url = https://github.com/ynput/ayon-automator.git
+	url = git@github.com:ynput/ayon-automator.git


### PR DESCRIPTION
## Changelog Description
This was done already in [PR#79](https://github.com/ynput/ayon-usd-resolver/pull/79), but found out that most probably incorrect merge somewhere else changed it back to different repo.

## Testing notes:
Not needed.
